### PR TITLE
Utilizes the avoidCache argument to bypass the cached association

### DIFF
--- a/spec/associations.spec.js
+++ b/spec/associations.spec.js
@@ -122,6 +122,18 @@ describe( 'Associations', () => {
 		});
 
 
+		it( 'allows for bypassing the cached collection', () => {
+			sandbox.stub( Property, 'get' ).resolves( properties );
+
+			return expect( user.getProperties() ).
+				to.eventually.deep.equal( properties ).
+				then( () => user.getProperties({}, true) ).
+				then( () => {
+					expect( Property.get ).to.have.been.calledTwice;
+				});
+		});
+
+
 		it( 'allows filter parameters to be passed to the datastore', () => {
 			sandbox.stub( Property, 'get' ).
 				resolves( properties.slice(0,2) );
@@ -266,6 +278,18 @@ describe( 'Associations', () => {
 		});
 
 
+		it( 'allows for bypassing the cached object', () => {
+			sandbox.stub( User, 'get' ).resolves( user );
+
+			return expect( property.getOwner() ).
+				to.eventually.deep.equal( user ).
+				then( () => property.getOwner({}, true) ).
+				then( () => {
+					expect( User.get ).to.have.been.calledTwice;
+				});
+		});
+
+
 		it.skip( 'allows parameters to be passed to the fetch', () => {
 			sandbox.stub( User, 'get' ).resolves( user );
 
@@ -369,6 +393,18 @@ describe( 'Associations', () => {
 				then( () => user.getProfile() ).
 				then( () => {
 					expect( Profile.get ).to.have.been.calledOnce;
+				});
+		});
+
+
+		it( 'allows for bypassing the cached object', () => {
+			sandbox.stub( Profile, 'get' ).resolves( profile );
+
+			return expect( user.getProfile() ).
+				to.eventually.deep.equal( profile ).
+				then( () => user.getProfile({}, true) ).
+				then( () => {
+					expect( Profile.get ).to.have.been.calledTwice;
 				});
 		});
 

--- a/src/associations.js
+++ b/src/associations.js
@@ -106,7 +106,7 @@ export class OneToManyAssociation extends Association {
 	getFor(origin, params={}, avoidCache=false) {
 		let targetClass = this.modelClass;
 
-		if ( !origin[ASSOCIATIONS_CACHE].has(this.name) ) {
+		if ( avoidCache || !origin[ASSOCIATIONS_CACHE].has(this.name) ) {
 			let url = this.urlFrom( origin );
 			logger.debug( `Fetching ${this.name} for ${origin} from ${url} with params: `, params );
 
@@ -127,7 +127,7 @@ export class OneToOneAssociation extends Association {
 	getFor(origin, params={}, avoidCache=false ) {
 		let targetClass = this.modelClass;
 
-		if ( !origin[ASSOCIATIONS_CACHE].has(this.name) ) {
+		if ( avoidCache || !origin[ASSOCIATIONS_CACHE].has(this.name) ) {
 			let url = this.urlFrom( origin );
 			logger.debug( `Fetching ${this.name} for ${origin} from ${url}` );
 
@@ -167,7 +167,7 @@ export class ManyToOneAssociation extends Association {
 	getFor(origin, params={}, avoidCache=false ) {
 		let targetClass = this.modelClass;
 
-		if ( !origin[ASSOCIATIONS_CACHE].has(this.name) ) {
+		if ( avoidCache || !origin[ASSOCIATIONS_CACHE].has(this.name) ) {
 			let promise = null;
 
 			if ( this.options.keyField ) {


### PR DESCRIPTION
Currently the avoidCache argument is not used. This commit allows
for refreshing the cache if avoidCache is true.